### PR TITLE
Fix requirements: add shap to requirements.in

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -12,6 +12,7 @@ pandas==1.3.*
 pydantic==1.9.*
 pyyaml==6.*
 scikit-learn==1.0.*
+shap==0.40.*
 tqdm==4.64.*
 tune-sklearn==0.4.*
 xgboost==1.5.*


### PR DESCRIPTION
## What does this PR do?
Add shap dependency to `requirements.in`. It seemed to be added to `requirements.txt` file but is missing in the `.in` file.

## Where should the reviewers start?
`requirements.in`
