### PR TITLE
Fix training script bugs

### DIFF
--- a/src/config/models.py
+++ b/src/config/models.py
@@ -23,7 +23,7 @@ class DataParams(BaseModel):
             feature_cols = [
                 feature
                 for feature in full_feature_list
-                if feature not in self.data_params.ignore_cols + [self.target_col]
+                if feature not in self.ignore_cols + [self.target_col]
             ]
         return feature_cols
 


### PR DESCRIPTION
## What does this PR do?
Fix two bugs:
* `ignore_cols` option in the `config.yaml` for the train script wasn't working due to a wrong class attribute being accessed.
* ~~The training script was indiscriminately dropping any row that had a null value. However, it's more precise to just drop those with null values in relevant cols (feature cols + target col + spatial CV group col).~~ Fixed in a previous commit already merged to main.

## Where should the reviewers start?
* I'll leave comments. Please see below.


